### PR TITLE
docs: update references to new repo name (TwinCAT-XAE-MCP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,5 +54,5 @@ nearly the entire automatable TE1000 surface.
   `ProduceXml`/`ConsumeXml`, variable linking, NetId targeting, rescans, NC inspection, and
   guarded activate/restart/download.
 
-[2.0.0]: https://github.com/Edge-JB/tc1000-MCP-TC-4026/releases
-[1.0.0]: https://github.com/Edge-JB/tc1000-MCP-TC-4026/releases
+[2.0.0]: https://github.com/Edge-JB/TwinCAT-XAE-MCP/releases
+[1.0.0]: https://github.com/Edge-JB/TwinCAT-XAE-MCP/releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ MCP client ──stdio──► index.js (Node 20) ──spawns──► 32-bit 
 ## Development
 
 ```powershell
-git clone https://github.com/Edge-JB/tc1000-MCP-TC-4026.git
-cd tc1000-MCP-TC-4026
+git clone https://github.com/Edge-JB/TwinCAT-XAE-MCP.git
+cd TwinCAT-XAE-MCP
 npm install
 npm run check        # node --check index.js — syntax-validate the server
 node index.js        # smoke test — prints "running on stdio" and waits

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > A [Model Context Protocol](https://modelcontextprotocol.io) server for **Beckhoff TwinCAT 3** engineering automation — drive the **TE1000 / XAE Automation Interface** from an AI agent or any MCP client.
 
-[![CI](https://github.com/Edge-JB/tc1000-MCP-TC-4026/actions/workflows/ci.yml/badge.svg)](https://github.com/Edge-JB/tc1000-MCP-TC-4026/actions/workflows/ci.yml)
+[![CI](https://github.com/Edge-JB/TwinCAT-XAE-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/Edge-JB/TwinCAT-XAE-MCP/actions/workflows/ci.yml)
 [![MCP](https://img.shields.io/badge/MCP-server-blue)](https://modelcontextprotocol.io)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 [![TwinCAT](https://img.shields.io/badge/TwinCAT-3%20%2F%20TE1000-orange)](https://www.beckhoff.com/twincat)
@@ -93,8 +93,8 @@ environment variable if your installation differs.
 ## Install
 
 ```powershell
-git clone https://github.com/Edge-JB/tc1000-MCP-TC-4026.git
-cd tc1000-MCP-TC-4026
+git clone https://github.com/Edge-JB/TwinCAT-XAE-MCP.git
+cd TwinCAT-XAE-MCP
 npm install
 ```
 
@@ -118,7 +118,7 @@ Point your client at the absolute path of `index.js` in your clone. Example
   "mcpServers": {
     "te1000": {
       "command": "node",
-      "args": ["C:\\path\\to\\tc1000-MCP-TC-4026\\index.js"]
+      "args": ["C:\\path\\to\\TwinCAT-XAE-MCP\\index.js"]
     }
   }
 }

--- a/examples/mcp-config.json
+++ b/examples/mcp-config.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "te1000": {
       "command": "node",
-      "args": ["C:\\path\\to\\tc1000-MCP-TC-4026\\index.js"],
+      "args": ["C:\\path\\to\\TwinCAT-XAE-MCP\\index.js"],
       "env": {
         "//TE1000_PROGID": "TcXaeShell.DTE.17.0 — set only if your XAE Shell ProgID differs"
       }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Edge-JB/tc1000-MCP-TC-4026.git"
+    "url": "git+https://github.com/Edge-JB/TwinCAT-XAE-MCP.git"
   },
-  "homepage": "https://github.com/Edge-JB/tc1000-MCP-TC-4026#readme",
+  "homepage": "https://github.com/Edge-JB/TwinCAT-XAE-MCP#readme",
   "bugs": {
-    "url": "https://github.com/Edge-JB/tc1000-MCP-TC-4026/issues"
+    "url": "https://github.com/Edge-JB/TwinCAT-XAE-MCP/issues"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Repo renamed `tc1000-MCP-TC-4026` → `TwinCAT-XAE-MCP` for clarity and discoverability. Updates badge URLs, clone instructions, and package.json/doc links to match. GitHub redirects the old URL automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)