### PR TITLE
fix(xae): error_list returns items via typed DTE2 (was always "unavailable")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] — 2026-06-24
+
+### Fixed
+- **`xae error_list` always reported "error list unavailable".** The 2.1.0 daemon
+  port read the Error List through raw IDispatch late binding
+  (`dynamic dte.ToolWindows.ErrorList`), which returns **null** on TcXaeShell —
+  `EnvDTE80.ToolWindows.get_ErrorList` is not reachable that way. `ReadErrorList`
+  now uses the **strongly-typed `DTE2`** cast (`GetTypedObjectForIUnknown`), exactly
+  like the PS bridge's `XaeErrorListProbe`, and again returns the live error/warning
+  list. The broad `catch → null` that masked the failure now surfaces the actual
+  exception in an `error` field (rendered as `error list unavailable: <reason>`).
+- Added typed `EnvDTE` / `EnvDTE80` / `Microsoft.VisualStudio.Interop` references
+  (resolved at runtime from the TcXaeShell `PublicAssemblies` dir by the new
+  `VsInterop` AssemblyResolve handler — not copied local, not GAC-dependent), for
+  the DTE members raw IDispatch cannot reach. Mirrors the existing typed
+  `TCatSysManagerLib` reference for vtable-only interfaces.
+
 ## [2.1.0] — 2026-06-24
 
 A **persistent native C#/.NET daemon** replaces the per-call `powershell.exe` spawn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project are documented here. The format is based on
   like the PS bridge's `XaeErrorListProbe`, and again returns the live error/warning
   list. The broad `catch → null` that masked the failure now surfaces the actual
   exception in an `error` field (rendered as `error list unavailable: <reason>`).
+  DTE acquisition (`ctx.Dte` / `GetIUnknownForObject`) is now inside the guarded
+  block, so a dead/absent XAE takes the graceful `{available:false, error:…}`
+  path instead of escaping as a hard `com_error`.
 - Added typed `EnvDTE` / `EnvDTE80` / `Microsoft.VisualStudio.Interop` references
   (resolved at runtime from the TcXaeShell `PublicAssemblies` dir by the new
   `VsInterop` AssemblyResolve handler — not copied local, not GAC-dependent), for

--- a/daemon/Actions/XaeActions.cs
+++ b/daemon/Actions/XaeActions.cs
@@ -482,10 +482,14 @@ namespace Te1000Daemon
         private static ErrorListResult ReadErrorList(ActionContext ctx, int limit, out string error)
         {
             error = null;
-            object rawDte = ctx.Dte(true);
-            IntPtr pUnk = Marshal.GetIUnknownForObject(rawDte);
+            IntPtr pUnk = IntPtr.Zero;
             try
             {
+                // Acquire the DTE inside the try so a dead/absent XAE (ctx.Dte
+                // throws) takes the graceful {available:false, error:...} path
+                // instead of escaping as a hard com_error.
+                object rawDte = ctx.Dte(true);
+                pUnk = Marshal.GetIUnknownForObject(rawDte);
                 EnvDTE80.DTE2 dte = (EnvDTE80.DTE2)Marshal.GetTypedObjectForIUnknown(pUnk, typeof(EnvDTE80.DTE2));
 
                 try { dte.ExecuteCommand("View.ErrorList", " "); }

--- a/daemon/Actions/XaeActions.cs
+++ b/daemon/Actions/XaeActions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Te1000Daemon
 {
@@ -355,13 +356,15 @@ namespace Te1000Daemon
             int limit = 200;
             if (ctx.Payload.Has("limit")) limit = ctx.Payload.Int("limit", 200);
 
-            ErrorListResult result = ReadErrorList(ctx, limit);
+            string error;
+            ErrorListResult result = ReadErrorList(ctx, limit, out error);
             if (result == null)
             {
                 var unavailable = new Json.JObj();
                 unavailable["available"] = false;
                 unavailable["count"] = 0;
                 unavailable["items"] = new Json.JArr();
+                if (!string.IsNullOrEmpty(error)) unavailable["error"] = error;
                 return unavailable;
             }
 
@@ -460,48 +463,57 @@ namespace Te1000Daemon
         }
 
         // ---- error-list reading (port of XaeErrorListProbe, bridge L205-260) -
-        // Reads the DTE ToolWindows ErrorList via late-bound dynamic. Returns null
-        // on any failure / when the error list is not reachable (matches the PS
-        // {available:false} path). Item key order matches the PS handler at
-        // L3935-3942: description, fileName, line, column, project, errorLevel.
+        // Reads the DTE ToolWindows ErrorList through the STRONGLY-TYPED DTE2 cast,
+        // exactly like the PS bridge's XaeErrorListProbe. Raw IDispatch late
+        // binding (`dynamic dte.ToolWindows.ErrorList`) returns NULL on TcXaeShell
+        // — EnvDTE80.ToolWindows.get_ErrorList is not reachable that way — so the
+        // earlier dynamic port always reported the list "unavailable". The typed
+        // cast (GetTypedObjectForIUnknown → DTE2) returns a live ErrorList. The
+        // EnvDTE PIAs are loaded at runtime by VsInterop. Returns null + an error
+        // string on failure (matches the PS {available:false} path). Item key order
+        // matches the PS handler at L3935-3942: description, fileName, line, column,
+        // project, errorLevel.
         private sealed class ErrorListResult
         {
             public int TotalCount;
             public Json.JArr Items;
         }
 
-        private static ErrorListResult ReadErrorList(ActionContext ctx, int limit)
+        private static ErrorListResult ReadErrorList(ActionContext ctx, int limit, out string error)
         {
+            error = null;
+            object rawDte = ctx.Dte(true);
+            IntPtr pUnk = Marshal.GetIUnknownForObject(rawDte);
             try
             {
-                dynamic dte = ctx.Dte(true);
+                EnvDTE80.DTE2 dte = (EnvDTE80.DTE2)Marshal.GetTypedObjectForIUnknown(pUnk, typeof(EnvDTE80.DTE2));
+
                 try { dte.ExecuteCommand("View.ErrorList", " "); }
                 catch { }
                 System.Threading.Thread.Sleep(1000);
 
-                dynamic errorList = ComHelpers.Safe<dynamic>(delegate() { return dte.ToolWindows.ErrorList; });
-                if (errorList == null) return null;
+                EnvDTE80.ErrorList errorList = dte.ToolWindows.ErrorList;
+                if (errorList == null) { error = "ToolWindows.ErrorList returned null"; return null; }
 
                 try { errorList.ShowErrors = true; } catch { }
                 try { errorList.ShowWarnings = true; } catch { }
                 try { errorList.ShowMessages = true; } catch { }
 
-                dynamic errorItems = errorList.ErrorItems;
-                int totalCount = (int)errorItems.Count;
+                EnvDTE80.ErrorItems errorItems = errorList.ErrorItems;
+                int totalCount = errorItems.Count;
                 int returnedCount = totalCount < limit ? totalCount : limit;
 
                 var items = new Json.JArr();
                 for (int i = 1; i <= returnedCount; i++)
                 {
-                    dynamic item = errorItems.Item(i);
-                    dynamic it = item;
+                    EnvDTE80.ErrorItem item = errorItems.Item(i);
                     var o = new Json.JObj();
-                    o["description"] = ComHelpers.SafeStr(delegate() { return it.Description; });
-                    o["fileName"] = ComHelpers.SafeStr(delegate() { return it.FileName; });
-                    o["line"] = NullableInt(delegate() { return it.Line; });
-                    o["column"] = NullableInt(delegate() { return it.Column; });
-                    o["project"] = ComHelpers.SafeStr(delegate() { return it.Project; });
-                    o["errorLevel"] = ComHelpers.SafeStr(delegate() { return it.ErrorLevel; });
+                    o["description"] = ComHelpers.SafeStr(delegate() { return item.Description; });
+                    o["fileName"] = ComHelpers.SafeStr(delegate() { return item.FileName; });
+                    o["line"] = NullableInt(delegate() { return item.Line; });
+                    o["column"] = NullableInt(delegate() { return item.Column; });
+                    o["project"] = ComHelpers.SafeStr(delegate() { return item.Project; });
+                    o["errorLevel"] = ComHelpers.SafeStr(delegate() { return item.ErrorLevel; });
                     items.Add(o);
                 }
 
@@ -510,9 +522,15 @@ namespace Te1000Daemon
                 result.Items = items;
                 return result;
             }
-            catch
+            catch (Exception ex)
             {
+                error = ex.GetType().Name + ": " + ex.Message;
+                Log.Error("ReadErrorList failed", ex);
                 return null;
+            }
+            finally
+            {
+                if (pUnk != IntPtr.Zero) Marshal.Release(pUnk);
             }
         }
 

--- a/daemon/Program.cs
+++ b/daemon/Program.cs
@@ -16,6 +16,10 @@ namespace Te1000Daemon
         [STAThread]
         private static int Main(string[] args)
         {
+            // Install the EnvDTE PIA resolver before any typed-DTE handler is
+            // JIT-compiled (the AssemblyResolve hook is AppDomain-wide).
+            VsInterop.EnsureResolver();
+
             string pipeName = "te1000-mcp";
             bool watch = true;
             bool autoDismiss = true;

--- a/daemon/Te1000Daemon.csproj
+++ b/daemon/Te1000Daemon.csproj
@@ -29,6 +29,17 @@
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <!--
+    TcXaeShell PublicAssemblies dir, resolved like build.ps1's TCatSysManagerLib
+    probe (64-bit install first, then x86). Supplies the EnvDTE / EnvDTE80 /
+    Microsoft.VisualStudio.Interop reference metadata at compile time; at runtime
+    the assemblies are loaded from this same dir by VsInterop's AssemblyResolve
+    handler (they are not copied local / not in a reachable GAC view).
+  -->
+  <PropertyGroup>
+    <XaePublicAssemblies Condition="'$(XaePublicAssemblies)' == '' And Exists('C:\Program Files\Beckhoff\TcXaeShell\Common7\IDE\PublicAssemblies\envdte80.dll')">C:\Program Files\Beckhoff\TcXaeShell\Common7\IDE\PublicAssemblies</XaePublicAssemblies>
+    <XaePublicAssemblies Condition="'$(XaePublicAssemblies)' == '' And Exists('C:\Program Files (x86)\Beckhoff\TcXaeShell\Common7\IDE\PublicAssemblies\envdte80.dll')">C:\Program Files (x86)\Beckhoff\TcXaeShell\Common7\IDE\PublicAssemblies</XaePublicAssemblies>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -66,9 +77,33 @@
       <EmbedInteropTypes>true</EmbedInteropTypes>
       <Private>false</Private>
     </Reference>
+    <!--
+      Typed EnvDTE interop for the handful of DTE members that raw IDispatch
+      late binding cannot reach. ToolWindows.ErrorList returns NULL through
+      late-bound `dynamic` on TcXaeShell, but a non-null typed ErrorList through
+      the strongly-typed DTE2 cast (see VsInterop / XaeActions.ReadErrorList).
+      NOT embedded (DTE2 is type-forwarded to Microsoft.VisualStudio.Interop) and
+      NOT copied local; loaded at runtime by VsInterop from $(XaePublicAssemblies).
+    -->
+    <Reference Include="EnvDTE">
+      <HintPath>$(XaePublicAssemblies)\envdte.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="EnvDTE80">
+      <HintPath>$(XaePublicAssemblies)\envdte80.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <HintPath>$(XaePublicAssemblies)\Microsoft.VisualStudio.Interop.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
+    <Compile Include="VsInterop.cs" />
     <Compile Include="Json.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="OleMessageFilter.cs" />

--- a/daemon/VsInterop.cs
+++ b/daemon/VsInterop.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+
+namespace Te1000Daemon
+{
+    // Runtime loader for the EnvDTE PIAs used by the typed DTE paths (see
+    // XaeActions.ReadErrorList). The daemon exe lives under C:\ProgramData and the
+    // PIAs (EnvDTE / EnvDTE80 / Microsoft.VisualStudio.Interop) are neither copied
+    // local nor in a GAC view the runtime probes, so we resolve them from the
+    // TcXaeShell PublicAssemblies dir on demand — mirroring the PS bridge's
+    // Get-XaePublicAssembliesPath (te1000-bridge.ps1 L64-76).
+    public static class VsInterop
+    {
+        private static int _installed;
+
+        // Same candidate roots as build.ps1 / Get-XaePublicAssembliesPath: prefer
+        // the 64-bit install, fall back to x86.
+        private static readonly string[] Roots =
+        {
+            @"C:\Program Files\Beckhoff\TcXaeShell\Common7\IDE\PublicAssemblies",
+            @"C:\Program Files (x86)\Beckhoff\TcXaeShell\Common7\IDE\PublicAssemblies",
+        };
+
+        private static readonly string[] Wanted =
+        {
+            "EnvDTE", "EnvDTE80", "Microsoft.VisualStudio.Interop",
+        };
+
+        // Idempotent; safe to call from any thread before the first typed-DTE use.
+        public static void EnsureResolver()
+        {
+            if (Interlocked.Exchange(ref _installed, 1) == 1) return;
+            AppDomain.CurrentDomain.AssemblyResolve += Resolve;
+        }
+
+        private static Assembly Resolve(object sender, ResolveEventArgs e)
+        {
+            string name;
+            try { name = new AssemblyName(e.Name).Name; }
+            catch { return null; }
+
+            bool wanted = false;
+            for (int i = 0; i < Wanted.Length; i++)
+                if (string.Equals(name, Wanted[i], StringComparison.OrdinalIgnoreCase)) { wanted = true; break; }
+            if (!wanted) return null;
+
+            foreach (var root in Roots)
+            {
+                try
+                {
+                    var path = Path.Combine(root, name + ".dll");
+                    if (File.Exists(path)) return Assembly.LoadFrom(path);
+                }
+                catch (Exception ex) { Log.Error("VsInterop.Resolve failed for " + name + " in " + root, ex); }
+            }
+            return null;
+        }
+    }
+}

--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ function textResult(data) {
     if (typeof data.xml === "string") return text(data.xml); // raw XML beats JSON-escaped XML
     if (Array.isArray(data.commands)) return text(`${data.count} commands\n${data.commands.join("\n")}`);
     if (Array.isArray(data.items) && "available" in data) {
-      if (!data.available) return text("error list unavailable");
+      if (!data.available) return text(data.error ? `error list unavailable: ${data.error}` : "error list unavailable");
       const lines = data.items.map((it) =>
         `${it.errorLevel || "?"}  ${it.fileName || ""}(${it.line ?? ""}): ${it.description || ""}${it.project ? ` [${it.project}]` : ""}`);
       return text([`${data.returned}/${data.count} items`, ...lines].join("\n"));
@@ -376,7 +376,7 @@ function need(params, keys, action) {
   }
 }
 
-const server = new McpServer({ name: "te1000-mcp", version: "2.1.0" });
+const server = new McpServer({ name: "te1000-mcp", version: "2.1.1" });
 
 server.registerTool(
   "xae",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "te1000-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MCP server for Beckhoff TwinCAT TE1000 / XAE Shell automation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Problem

`xae error_list` always returned **`error list unavailable`** against a live TcXaeShell with a solution open and the System Manager available.

## Root cause

The 2.1.0 native daemon port reads the Error List through **raw IDispatch late binding**:

```csharp
dynamic errorList = ComHelpers.Safe<dynamic>(() => dte.ToolWindows.ErrorList); // -> null on TcXaeShell
if (errorList == null) return null;                                            // -> "unavailable"
```

`EnvDTE80.ToolWindows.get_ErrorList` is **not reachable via raw IDispatch** — it returns `null` (verified live; `Windows.Item(vsWindowKindErrorList).Object` is null too). The original PS bridge (`XaeErrorListProbe`) never hit this because it uses the **strongly-typed `DTE2`** cast. The port dropped the typed cast in favour of `dynamic`, and a broad `catch -> return null` masked the failure entirely.

## Fix

- `ReadErrorList` now uses the typed `DTE2` cast (`Marshal.GetTypedObjectForIUnknown(pUnk, typeof(DTE2))`), exactly like `XaeErrorListProbe`, and iterates the typed `ErrorList` / `ErrorItems`.
- Added typed `EnvDTE` / `EnvDTE80` / `Microsoft.VisualStudio.Interop` references, resolved **at runtime** from the TcXaeShell `PublicAssemblies` dir by a new `VsInterop` `AssemblyResolve` handler (not copied local, not GAC-dependent — mirrors `Get-XaePublicAssembliesPath` in the PS bridge). This is the same pattern the daemon already uses for the vtable-only `TCatSysManagerLib` interfaces.
- The broad swallow now records the real exception in an `error` field; the front-end renders `error list unavailable: <reason>` so future failures are diagnosable instead of opaque.
- Bumped to **2.1.1**.

## Verification

Built with the in-box MSBuild (`daemon/build.ps1`), restarted the daemon, and called the live tool. It returned `10/104 items` with full detail (errorLevel / file / line / description / project) drawn from the open CabSort solution. Before the fix the same call returned `error list unavailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
