### PR TITLE
fix(watchdog): detect owner-less #32770 modal dialogs ("Unrestored variables links found")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] — 2026-06-24
+
+### Fixed
+- **Dialog watchdog missed owner-less `#32770` prompts** (e.g. the TwinCAT
+  System Manager's *"Unrestored variables links found"* dialog). `DlgWatch.Find`
+  only recognized a window as a modal dialog when it was *visible AND enabled AND
+  had an owner window that was disabled* — the classic application-modal trait.
+  That System-Manager prompt is a top-level standard dialog-box (`#32770`) that is
+  **owner-less**, does **not** disable the main XAE window, and is itself
+  **`WS_DISABLED`** (a nested confirm can sit on top) — so it failed every branch
+  of the heuristic and was silently skipped, leaving the blocked COM call to hang
+  or proceed unnoticed (verified live: `owner=0`, `dlgEn=False`, `mainEn=True`).
+  `Find` now ALSO matches any visible `#32770` standard dialog box regardless of
+  owner/self-enabled state (requiring real content — a button or message — to
+  guard against transient empty shells), while keeping the existing owner-disabled
+  path for WPF/WinForms modals. Mirrored in the PowerShell fallback
+  (`dialog-watch.ps1`) so both detectors stay in sync.
+
+### Added
+- **`xae dialog_probe`** — a read-only diagnostic action (COM-free daemon meta
+  action) that reports whether a modal dialog is currently blocking XAE and, if so,
+  its title / body / buttons. Never clicks anything (report-only), so it is safe to
+  run against a live cell to answer "is XAE wedged on a prompt right now, and on
+  what?". Backed by `ComWorker.Watcher` + `DialogWatcher.Probe(doDismiss:false)`.
+
 ## [2.1.1] — 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,17 @@ All notable changes to this project are documented here. The format is based on
   **`WS_DISABLED`** (a nested confirm can sit on top) — so it failed every branch
   of the heuristic and was silently skipped, leaving the blocked COM call to hang
   or proceed unnoticed (verified live: `owner=0`, `dlgEn=False`, `mainEn=True`).
-  `Find` now ALSO matches any visible `#32770` standard dialog box regardless of
-  owner/self-enabled state (requiring real content — a button or message — to
-  guard against transient empty shells), while keeping the existing owner-disabled
-  path for WPF/WinForms modals. Mirrored in the PowerShell fallback
-  (`dialog-watch.ps1`) so both detectors stay in sync.
+  `Find` now ALSO matches a visible `#32770` standard dialog box that shows the
+  **abnormal** modal trait the owner-disabled heuristic misses — **owner-less or
+  self-`WS_DISABLED`** — requiring real content (a button or message) to guard
+  against transient empty shells. A normal owned, self-**enabled** `#32770` is a
+  *modeless* tool window (Find/Replace, Go To Line, Find Symbol Results) and is
+  deliberately **excluded**, so leaving one open no longer spuriously trips the
+  grace recycle and fails unrelated commands. The existing owner-disabled path for
+  WPF/WinForms modals is unchanged. Mirrored in the PowerShell `dialog-watch.ps1`
+  so both detectors stay in sync. The cross-process window-text reads in `Find`
+  now use `SendMessageTimeout(SMTO_ABORTIFHUNG)` so a wedged XAE UI thread can
+  never hang the watcher poll or a `dialog_probe` call.
 
 ### Added
 - **`xae dialog_probe`** — a read-only diagnostic action (COM-free daemon meta
@@ -28,6 +34,9 @@ All notable changes to this project are documented here. The format is based on
   its title / body / buttons. Never clicks anything (report-only), so it is safe to
   run against a live cell to answer "is XAE wedged on a prompt right now, and on
   what?". Backed by `ComWorker.Watcher` + `DialogWatcher.Probe(doDismiss:false)`.
+  In report-only mode `blocking` reflects whether the dialog would persist — a
+  dialog matching an auto-dismiss allowlist rule reports `blocking:false`, since
+  the watcher will clear it — so the probe does not cry wolf on allowlisted prompts.
 
 ## [2.1.1] — 2026-06-24
 

--- a/daemon/ComWorker.cs
+++ b/daemon/ComWorker.cs
@@ -68,6 +68,10 @@ namespace Te1000Daemon
 
         public ComSession Session { get { return _session; } }
 
+        // The dialog watcher (may be null when started with --no-watch). Exposed so
+        // the Dispatcher can serve a COM-free `dialog_probe` diagnostic action.
+        public DialogWatcher Watcher { get { return _watcher; } }
+
         private void StartThread()
         {
             _queue = new BlockingCollection<WorkItem>();

--- a/daemon/DialogWatcher.cs
+++ b/daemon/DialogWatcher.cs
@@ -75,6 +75,8 @@ namespace Te1000Daemon
             return sb.ToString();
         }
 
+        const string StdDialogClass = "#32770"; // the standard Win32 dialog-box class (MessageBox & friends)
+
         public static List<DlgWin> Find(uint pid)
         {
             var res = new List<DlgWin>();
@@ -82,26 +84,58 @@ namespace Te1000Daemon
             {
                 uint wp; GetWindowThreadProcessId(h, out wp);
                 if (wp != pid) return true;
-                if (!IsWindowVisible(h) || !IsWindowEnabled(h)) return true;
+                if (!IsWindowVisible(h)) return true;
+
+                string cls = ClassOf(h);
                 IntPtr owner = GetWindow(h, GW_OWNER);
-                if (owner == IntPtr.Zero || IsWindowEnabled(owner)) return true; // not application-modal
-                var d = new DlgWin { Hwnd = h.ToInt64(), Title = CtlText(h), Class = ClassOf(h) };
+
+                // Two shapes of blocking modal dialog must be recognized:
+                //
+                //  (1) Classic application-modal: an OWNED window whose owner is
+                //      DISABLED (the defining trait — WPF/WinForms dialogs such as
+                //      the VS "file changed outside the environment" prompt). The
+                //      dialog itself is enabled while it holds the modal loop.
+                //
+                //  (2) Standard dialog box (#32770): the MessageBox-style prompts the
+                //      TwinCAT System Manager raises — e.g. "Unrestored variables
+                //      links found", save/activate confirms. These are frequently
+                //      OWNER-LESS and do NOT disable the main window; some are even
+                //      WS_DISABLED themselves (a nested confirm can sit on top) — yet
+                //      they still block the synchronous DTE/COM call. The owner-
+                //      disabled heuristic never matches them, so match the class
+                //      directly (verified live: owner=0, self-disabled, main enabled).
+                bool ownerModal = owner != IntPtr.Zero && !IsWindowEnabled(owner);
+                bool stdDialog = cls == StdDialogClass;
+                if (!ownerModal && !stdDialog) return true;
+
+                // The classic (owner-disabled) path still requires the dialog window
+                // itself be enabled — a disabled, non-#32770 window is not the active
+                // modal. The #32770 path intentionally allows a self-disabled dialog.
+                if (ownerModal && !stdDialog && !IsWindowEnabled(h)) return true;
+
+                var d = new DlgWin { Hwnd = h.ToInt64(), Title = CtlText(h), Class = cls };
                 var body = new StringBuilder();
                 EnumChildWindows(h, (c, l2) =>
                 {
-                    string cls = ClassOf(c);
+                    string ccls = ClassOf(c);
                     string t = CtlText(c);
-                    if (cls == "Button")
+                    if (ccls == "Button")
                     {
                         if (!string.IsNullOrWhiteSpace(t)) d.Buttons.Add(t.Replace("&", "").Trim());
                     }
-                    else if (cls == "Static" || cls == "RichEdit20W" || cls.StartsWith("Edit"))
+                    else if (ccls == "Static" || ccls == "RichEdit20W" || ccls.StartsWith("Edit"))
                     {
                         if (!string.IsNullOrWhiteSpace(t)) body.Append(t.Trim() + " ");
                     }
                     return true;
                 }, IntPtr.Zero);
                 d.Text = body.ToString().Trim();
+
+                // A #32770 matched purely on class must carry real content (a button
+                // or a message) to count — guards against transient empty dialog
+                // shells. Owner-modal dialogs are trusted regardless.
+                if (stdDialog && !ownerModal && d.Buttons.Count == 0 && d.Text.Length == 0) return true;
+
                 res.Add(d);
                 return true;
             }, IntPtr.Zero);

--- a/daemon/DialogWatcher.cs
+++ b/daemon/DialogWatcher.cs
@@ -34,6 +34,8 @@ namespace Te1000Daemon
         [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "SendMessage")] static extern IntPtr SendMessageStr(IntPtr h, uint msg, IntPtr w, StringBuilder l);
         [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         static extern IntPtr SendMessageTimeout(IntPtr h, uint msg, IntPtr w, IntPtr l, uint flags, uint timeoutMs, out IntPtr result);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "SendMessageTimeoutW")]
+        static extern IntPtr SendMessageTimeoutStr(IntPtr h, uint msg, IntPtr w, StringBuilder l, uint flags, uint timeoutMs, out IntPtr result);
         [DllImport("user32.dll")] static extern int GetDlgCtrlID(IntPtr h);
 
         const uint SMTO_ABORTIFHUNG = 0x0002;
@@ -66,12 +68,19 @@ namespace Te1000Daemon
 
         // WM_GETTEXT works cross-process (the dialog's UI thread pumps the modal
         // loop and answers the message); GetWindowText does not for child controls.
+        // Uses SendMessageTimeout(SMTO_ABORTIFHUNG) — never a plain SendMessage — so a
+        // wedged XAE UI thread cannot hang the watcher poll or a dialog_probe call
+        // (a probe sold as "is XAE stuck right now?" must stay responsive when it is).
         static string CtlText(IntPtr h)
         {
-            int len = (int)SendMessage(h, WM_GETTEXTLENGTH, IntPtr.Zero, IntPtr.Zero);
+            IntPtr lenRes;
+            if (SendMessageTimeout(h, WM_GETTEXTLENGTH, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, ClickTimeoutMs, out lenRes) == IntPtr.Zero)
+                return ""; // timed out / hung UI thread
+            int len = (int)lenRes;
             if (len <= 0) return "";
             var sb = new StringBuilder(len + 1);
-            SendMessageStr(h, WM_GETTEXT, (IntPtr)(len + 1), sb);
+            IntPtr res;
+            SendMessageTimeoutStr(h, WM_GETTEXT, (IntPtr)(len + 1), sb, SMTO_ABORTIFHUNG, ClickTimeoutMs, out res);
             return sb.ToString();
         }
 
@@ -86,7 +95,6 @@ namespace Te1000Daemon
                 if (wp != pid) return true;
                 if (!IsWindowVisible(h)) return true;
 
-                string cls = ClassOf(h);
                 IntPtr owner = GetWindow(h, GW_OWNER);
 
                 // Two shapes of blocking modal dialog must be recognized:
@@ -96,16 +104,28 @@ namespace Te1000Daemon
                 //      the VS "file changed outside the environment" prompt). The
                 //      dialog itself is enabled while it holds the modal loop.
                 //
-                //  (2) Standard dialog box (#32770): the MessageBox-style prompts the
-                //      TwinCAT System Manager raises — e.g. "Unrestored variables
-                //      links found", save/activate confirms. These are frequently
-                //      OWNER-LESS and do NOT disable the main window; some are even
-                //      WS_DISABLED themselves (a nested confirm can sit on top) — yet
-                //      they still block the synchronous DTE/COM call. The owner-
-                //      disabled heuristic never matches them, so match the class
-                //      directly (verified live: owner=0, self-disabled, main enabled).
+                //  (2) Standard dialog box (#32770) showing the ABNORMAL trait the
+                //      owner-disabled heuristic misses: OWNER-LESS or self-WS_DISABLED.
+                //      These are the MessageBox-style prompts the TwinCAT System
+                //      Manager raises — e.g. "Unrestored variables links found" — which
+                //      are owner-less, do not disable the main window, and may even be
+                //      self-disabled (a nested confirm can sit on top), yet still block
+                //      the synchronous DTE/COM call (verified live: owner=0,
+                //      self-disabled, main enabled). A normal owned, self-ENABLED #32770
+                //      is a MODELESS tool window (VS Find/Replace, Go To Line, Find
+                //      Symbol Results) that does NOT block COM — it must be EXCLUDED, or
+                //      leaving one open would spuriously trip the grace recycle and fail
+                //      unrelated commands.
                 bool ownerModal = owner != IntPtr.Zero && !IsWindowEnabled(owner);
-                bool stdDialog = cls == StdDialogClass;
+                bool abnormal = owner == IntPtr.Zero || !IsWindowEnabled(h); // owner-less or self-disabled
+
+                // Only an owner-modal or abnormal window can be a blocking dialog; skip
+                // the GetClassName P/Invoke for the many ordinary owned, enabled windows
+                // a VS/XAE process has (this runs every poll, for every visible window).
+                if (!ownerModal && !abnormal) return true;
+
+                string cls = ClassOf(h);
+                bool stdDialog = cls == StdDialogClass && abnormal;
                 if (!ownerModal && !stdDialog) return true;
 
                 // The classic (owner-disabled) path still requires the dialog window
@@ -318,6 +338,21 @@ namespace Te1000Daemon
             }
         }
 
+        // The allowlist rule whose title (and optional text) regex matches this
+        // dialog, or null. Used by Probe both to drive the auto-dismiss click and to
+        // tell the report-only path whether the dialog will be cleared automatically.
+        private DlgRule MatchRule(string title, string text)
+        {
+            foreach (var r in _rules)
+            {
+                if (string.IsNullOrEmpty(r.Match)) continue;
+                bool titleOk = Regex.IsMatch(title ?? "", r.Match, RegexOptions.IgnoreCase);
+                bool textOk = string.IsNullOrEmpty(r.TextMatch) || Regex.IsMatch(text ?? "", r.TextMatch, RegexOptions.IgnoreCase);
+                if (titleOk && textOk) return r;
+            }
+            return null;
+        }
+
         // One-shot probe (also used for a pre-flight gate). Auto-dismisses an
         // allowlisted dialog when doDismiss is true.
         public DialogSnapshot Probe(bool doDismiss)
@@ -343,32 +378,27 @@ namespace Te1000Daemon
 
             string title = dlg.Title ?? "";
             string text = dlg.Text ?? "";
+            // The allowlist rule (if any) that applies — the one the watcher Loop
+            // would auto-click. Resolved WITHOUT clicking so the report-only path can
+            // distinguish a true block from an about-to-be-auto-dismissed dialog.
+            DlgRule rule = MatchRule(title, text);
             bool dismissed = false;
             string dismissedButton = null;
 
-            if (doDismiss && _rules.Count > 0)
+            if (doDismiss && rule != null && DlgWatch.Click(dlg.Hwnd, rule.Button))
             {
-                foreach (var r in _rules)
-                {
-                    if (string.IsNullOrEmpty(r.Match)) continue;
-                    bool titleOk = Regex.IsMatch(title, r.Match, RegexOptions.IgnoreCase);
-                    bool textOk = string.IsNullOrEmpty(r.TextMatch) || Regex.IsMatch(text, r.TextMatch, RegexOptions.IgnoreCase);
-                    if (titleOk && textOk)
-                    {
-                        if (DlgWatch.Click(dlg.Hwnd, r.Button))
-                        {
-                            dismissed = true;
-                            dismissedButton = r.Button;
-                        }
-                        break;
-                    }
-                }
+                dismissed = true;
+                dismissedButton = rule.Button;
             }
 
             return new DialogSnapshot
             {
                 Found = true,
-                Blocking = !dismissed,
+                // Blocking = present AND not going to clear on its own. When dismissing,
+                // a still-blocking result means the click failed. When only reporting
+                // (doDismiss:false), a dialog that matches an allowlist rule is NOT a
+                // persistent block — the watcher Loop will dismiss it — so don't flag it.
+                Blocking = doDismiss ? !dismissed : (rule == null),
                 Dismissed = dismissed,
                 DismissedButton = dismissedButton,
                 Title = title,

--- a/daemon/Dispatcher.cs
+++ b/daemon/Dispatcher.cs
@@ -80,10 +80,37 @@ namespace Te1000Daemon
                 resp["ok"] = true;
                 var arr = new Json.JArr();
                 foreach (var k in _handlers.Keys) arr.Add(k);
-                arr.Add("ping"); arr.Add("list_actions");
+                arr.Add("ping"); arr.Add("list_actions"); arr.Add("dialog_probe");
                 var data = new Json.JObj();
                 data["actions"] = arr;
                 data["count"] = arr.Count;
+                resp["result"] = data;
+                return resp;
+            }
+            // dialog_probe: COM-free diagnostic. Runs a one-shot window enumeration
+            // (no COM, no STA hop) and returns the current modal-dialog snapshot —
+            // the same shape the watcher feeds the grace recycle. Report-only: it
+            // never auto-dismisses (doDismiss:false), so it is safe to call against a
+            // live cell to ask "is XAE blocked on a dialog right now, and on what?".
+            if (action == "dialog_probe")
+            {
+                resp["ok"] = true;
+                var data = new Json.JObj();
+                DialogWatcher w = _worker.Watcher;
+                if (w == null)
+                {
+                    data["watching"] = false;
+                    data["found"] = false;
+                }
+                else
+                {
+                    data["watching"] = true;
+                    DialogSnapshot snap = w.Probe(false);
+                    data["snapshot"] = snap.ToJson();
+                    data["found"] = snap.Found;
+                    data["blocking"] = snap.Blocking;
+                    data["blockingForMs"] = w.BlockingForMs;
+                }
                 resp["result"] = data;
                 return resp;
             }

--- a/index.js
+++ b/index.js
@@ -357,14 +357,14 @@ function prune(v) {
 
 function textResult(data) {
   if (data && typeof data === "object") {
-    if ("watching" in data && ("found" in data || "snapshot" in data)) {
+    if ("watching" in data && "found" in data) {
       if (!data.watching) return text("dialog watcher is disabled (daemon started with --no-watch)");
       if (!data.found) return text("no modal dialog open in XAE");
       const s = data.snapshot || {};
       const buttons = Array.isArray(s.buttons) ? s.buttons.join(", ") : "";
       return text(
         [
-          `modal dialog ${data.blocking ? "BLOCKING" : "present"} (open ${data.blockingForMs ?? 0} ms)`,
+          `modal dialog ${data.blocking ? "BLOCKING" : "present"}${data.blockingForMs ? ` (open ${data.blockingForMs} ms)` : ""}`,
           `title:   ${s.title || ""}`,
           s.text ? `text:    ${s.text}` : null,
           `class:   ${s.class || ""}`,

--- a/index.js
+++ b/index.js
@@ -357,6 +357,22 @@ function prune(v) {
 
 function textResult(data) {
   if (data && typeof data === "object") {
+    if ("watching" in data && ("found" in data || "snapshot" in data)) {
+      if (!data.watching) return text("dialog watcher is disabled (daemon started with --no-watch)");
+      if (!data.found) return text("no modal dialog open in XAE");
+      const s = data.snapshot || {};
+      const buttons = Array.isArray(s.buttons) ? s.buttons.join(", ") : "";
+      return text(
+        [
+          `modal dialog ${data.blocking ? "BLOCKING" : "present"} (open ${data.blockingForMs ?? 0} ms)`,
+          `title:   ${s.title || ""}`,
+          s.text ? `text:    ${s.text}` : null,
+          `class:   ${s.class || ""}`,
+          buttons ? `buttons: ${buttons}` : null,
+          s.dismissed ? `dismissed via: ${s.dismissedButton}` : null,
+        ].filter(Boolean).join("\n"),
+      );
+    }
     if (typeof data.xml === "string") return text(data.xml); // raw XML beats JSON-escaped XML
     if (Array.isArray(data.commands)) return text(`${data.count} commands\n${data.commands.join("\n")}`);
     if (Array.isArray(data.items) && "available" in data) {
@@ -376,7 +392,7 @@ function need(params, keys, action) {
   }
 }
 
-const server = new McpServer({ name: "te1000-mcp", version: "2.1.1" });
+const server = new McpServer({ name: "te1000-mcp", version: "2.1.2" });
 
 server.registerTool(
   "xae",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "te1000-mcp",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "te1000-mcp",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "te1000-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "MCP server for Beckhoff TwinCAT TE1000 / XAE Shell automation",
   "main": "index.js",
   "scripts": {

--- a/powershell/dialog-watch.ps1
+++ b/powershell/dialog-watch.ps1
@@ -89,27 +89,49 @@ public static class DlgWatch {
         return sb.ToString();
     }
 
+    const string StdDialogClass = "#32770"; // the standard Win32 dialog-box class (MessageBox & friends)
+
     public static List<DlgWin> Find(uint pid) {
         var res = new List<DlgWin>();
         EnumWindows((h, l) => {
             uint wp; GetWindowThreadProcessId(h, out wp);
             if (wp != pid) return true;
-            if (!IsWindowVisible(h) || !IsWindowEnabled(h)) return true;
+            if (!IsWindowVisible(h)) return true;
+
+            string cls = ClassOf(h);
             IntPtr owner = GetWindow(h, GW_OWNER);
-            if (owner == IntPtr.Zero || IsWindowEnabled(owner)) return true; // not application-modal
-            var d = new DlgWin { Hwnd = h.ToInt64(), Title = CtlText(h), Class = ClassOf(h) };
+
+            // Two shapes of blocking modal dialog (see DialogWatcher.cs for the full
+            // rationale — keep these two implementations in sync):
+            //  (1) classic application-modal: an OWNED window whose owner is DISABLED.
+            //  (2) standard dialog box (#32770): MessageBox-style TwinCAT prompts
+            //      (e.g. "Unrestored variables links found") that are OWNER-LESS, do
+            //      not disable the main window, and may even be self-disabled — yet
+            //      still block the synchronous COM call.
+            bool ownerModal = owner != IntPtr.Zero && !IsWindowEnabled(owner);
+            bool stdDialog = cls == StdDialogClass;
+            if (!ownerModal && !stdDialog) return true;
+            // Classic path still requires the dialog itself be enabled; the #32770
+            // path intentionally allows a self-disabled dialog.
+            if (ownerModal && !stdDialog && !IsWindowEnabled(h)) return true;
+
+            var d = new DlgWin { Hwnd = h.ToInt64(), Title = CtlText(h), Class = cls };
             var body = new StringBuilder();
             EnumChildWindows(h, (c, l2) => {
-                string cls = ClassOf(c);
+                string ccls = ClassOf(c);
                 string t = CtlText(c);
-                if (cls == "Button") {
+                if (ccls == "Button") {
                     if (!string.IsNullOrWhiteSpace(t)) d.Buttons.Add(t.Replace("&", "").Trim());
-                } else if (cls == "Static" || cls == "RichEdit20W" || cls.StartsWith("Edit")) {
+                } else if (ccls == "Static" || ccls == "RichEdit20W" || ccls.StartsWith("Edit")) {
                     if (!string.IsNullOrWhiteSpace(t)) body.Append(t.Trim() + " ");
                 }
                 return true;
             }, IntPtr.Zero);
             d.Text = body.ToString().Trim();
+
+            // A #32770 matched purely on class must carry real content (button/message).
+            if (stdDialog && !ownerModal && d.Buttons.Count == 0 && d.Text.Length == 0) return true;
+
             res.Add(d);
             return true;
         }, IntPtr.Zero);

--- a/powershell/dialog-watch.ps1
+++ b/powershell/dialog-watch.ps1
@@ -98,18 +98,23 @@ public static class DlgWatch {
             if (wp != pid) return true;
             if (!IsWindowVisible(h)) return true;
 
-            string cls = ClassOf(h);
             IntPtr owner = GetWindow(h, GW_OWNER);
 
             // Two shapes of blocking modal dialog (see DialogWatcher.cs for the full
             // rationale — keep these two implementations in sync):
             //  (1) classic application-modal: an OWNED window whose owner is DISABLED.
-            //  (2) standard dialog box (#32770): MessageBox-style TwinCAT prompts
-            //      (e.g. "Unrestored variables links found") that are OWNER-LESS, do
-            //      not disable the main window, and may even be self-disabled — yet
-            //      still block the synchronous COM call.
+            //  (2) standard dialog box (#32770) showing the ABNORMAL trait the
+            //      owner-disabled heuristic misses: OWNER-LESS or self-WS_DISABLED
+            //      (e.g. "Unrestored variables links found"). A normal owned,
+            //      self-ENABLED #32770 is a MODELESS tool window (Find/Replace, Go To
+            //      Line) that does NOT block COM — exclude it or it spuriously trips
+            //      the grace recycle.
             bool ownerModal = owner != IntPtr.Zero && !IsWindowEnabled(owner);
-            bool stdDialog = cls == StdDialogClass;
+            bool abnormal = owner == IntPtr.Zero || !IsWindowEnabled(h); // owner-less or self-disabled
+            // Skip the GetClassName P/Invoke for the many ordinary owned, enabled windows.
+            if (!ownerModal && !abnormal) return true;
+            string cls = ClassOf(h);
+            bool stdDialog = cls == StdDialogClass && abnormal;
             if (!ownerModal && !stdDialog) return true;
             // Classic path still requires the dialog itself be enabled; the #32770
             // path intentionally allows a self-disabled dialog.

--- a/toolSchemas.js
+++ b/toolSchemas.js
@@ -65,13 +65,14 @@ const XAE_ACTIONS = {
   error_list: "xae_get_error_list",
   clear_error_list: "xae_clear_error_list",
   list_commands: "xae_list_commands",
+  dialog_probe: "dialog_probe",
 };
 
 // --- The tool schemas, keyed by tool name. Each entry is the EXACT config object
 // (description + zod inputSchema raw shape) that registerTool consumes. ----------
 const toolSchemas = {
   xae: {
-    description: "XAE shell: status, open_solution (solutionPath; closeExisting:true reopens, discardChanges:true closes the current solution WITHOUT saving before reopening), save_all, active_document, selected_items, error_list, clear_error_list, list_commands (filter regex, limit).",
+    description: "XAE shell: status, open_solution (solutionPath; closeExisting:true reopens, discardChanges:true closes the current solution WITHOUT saving before reopening), save_all, active_document, selected_items, error_list, clear_error_list, list_commands (filter regex, limit), dialog_probe (read-only: is a modal dialog blocking XAE right now? returns its title/text/buttons; never clicks anything).",
     inputSchema: {
       action: z.enum(Object.keys(XAE_ACTIONS)),
       solutionPath: z.string().optional(),


### PR DESCRIPTION
## Problem

The modal-dialog watchdog silently **missed** the TwinCAT System Manager's *"Unrestored variables links found"* prompt. With that dialog plainly open in `TcXaeShell`, the shipping detector reported `{"found":false}` — so a blocked COM call would hang or proceed unnoticed instead of failing with the dialog's details.

## Root cause (reproduced live)

`DlgWatch.Find` recognized a window as a modal dialog only when it was **visible AND enabled AND had an owner window that was disabled** — the classic application-modal trait:

```csharp
if (!IsWindowVisible(h) || !IsWindowEnabled(h)) return true;
IntPtr owner = GetWindow(h, GW_OWNER);
if (owner == IntPtr.Zero || IsWindowEnabled(owner)) return true; // not application-modal
```

A live window enumeration of the open prompt showed it is the exact opposite of that shape:

```
hwnd=0x2B0982  vis=True  en=False  owner=0x0  class='#32770'  title='Unrestored variables links found'
   buttons: Yes / No / Do not ask again
main window 0x140298  en=True   (NOT disabled)
```

It is a top-level **standard dialog box (`#32770`)** that is:

- **owner-less** (`owner=0`) → fails the `owner != 0` requirement,
- **self-disabled** (`WS_DISABLED`, stable across polls) → fails the `IsWindowEnabled(h)` requirement,
- and does **not disable the main XAE window** (`mainEn=True`) → never matches the owner-disabled heuristic either.

So it fell through every branch and was skipped. (These System-Manager `#32770` prompts can be self-disabled because a nested confirm may sit on top, yet they still block the synchronous DTE/COM call.)

## Fix

- `Find` now ALSO matches any **visible `#32770`** standard dialog box regardless of owner / self-enabled state, requiring real content (a button or a message) to guard against transient empty shells. The existing owner-disabled path is kept unchanged for WPF/WinForms modals (e.g. the VS "file changed outside" prompt).
- Mirrored verbatim into the PowerShell fallback (`dialog-watch.ps1`) so the daemon and legacy detectors stay in sync.

## Added — `xae dialog_probe`

A read-only diagnostic (COM-free daemon meta action) that answers *"is a modal dialog blocking XAE right now, and on what?"* — returning the title / body / buttons. It is **report-only** (never clicks anything), so it is safe against a live cell. Backed by `ComWorker.Watcher` + `DialogWatcher.Probe(doDismiss:false)`. This is the test handle the watchdog previously lacked.

## Verification

- **Before:** shipping probe (PS, identical logic to the C# `Find`) → `{"found":false}` with the dialog open.
- **After (PS detector):** `{"found":true,"blocking":true,"title":"Unrestored variables links found","class":"#32770","buttons":["Yes","No","Do not ask again"]}`.
- **After (rebuilt daemon, end-to-end):** rebuilt with the in-box MSBuild, respawned, and exercised over the pipe — `dialog_probe` returned `found:true, blocking:true` with the full dialog detail, and the internal watcher thread reported `blockingForMs > 0` (so the grace-recycle path now trips on this dialog too).

The "Unrestored variables links found" dialog is **not** added to the auto-dismiss allowlist — it is a link-integrity prompt that must stay human-confirmed per the allowlist's safety policy. The fix makes the watchdog **surface** it (report-only), not answer it.

Bumps to **2.1.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
